### PR TITLE
Prevent user from creating an order without name

### DIFF
--- a/app/src/main/java/com/ably/tracking/demo/publisher/main/AddOrderDialog.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/main/AddOrderDialog.kt
@@ -1,0 +1,80 @@
+package com.ably.tracking.demo.publisher.main
+
+import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.ably.tracking.demo.publisher.R
+
+@Composable
+fun AddOrderDialog(setShowDialog: (Boolean) -> Unit, onConfirm: (String, String, String) -> Unit) {
+    var orderName by rememberSaveable { mutableStateOf("") }
+    var destinationLatitude by rememberSaveable { mutableStateOf("51.1065859") }
+    var destinationLongitude by rememberSaveable { mutableStateOf("17.0312766") }
+
+    AlertDialog(
+        onDismissRequest = {
+            setShowDialog(false)
+        },
+        title = {
+            Text(
+                modifier = Modifier.padding(8.dp),
+                text = stringResource(id = R.string.add_order_dialog_title)
+            )
+        },
+        confirmButton = {
+            Button(
+                enabled = orderName.isNotBlank(),
+                onClick = {
+                    // Change the state to close the dialog
+                    setShowDialog(false)
+                    onConfirm(orderName, destinationLatitude, destinationLongitude)
+                },
+            ) {
+                Text(stringResource(id = R.string.add_order_dialog_confirm_button))
+            }
+        },
+        text = {
+            Column {
+                TextInput(orderName, R.string.add_order_dialog_order_name_hint) { orderName = it }
+                TextInput(
+                    destinationLatitude,
+                    R.string.add_order_dialog_order_latitude_hint
+                ) { destinationLatitude = it }
+                TextInput(
+                    destinationLongitude,
+                    R.string.add_order_dialog_order_longitude_hint
+                ) { destinationLongitude = it }
+            }
+        },
+    )
+}
+
+@Composable
+private fun TextInput(
+    orderName: String,
+    @StringRes labelRes: Int,
+    onValueChange: (String) -> Unit
+) {
+    TextField(
+        modifier = Modifier.padding(8.dp),
+        value = orderName,
+        onValueChange = onValueChange,
+        label = {
+            Text(
+                stringResource(id = labelRes)
+            )
+        }
+    )
+}

--- a/app/src/main/java/com/ably/tracking/demo/publisher/main/MainScreen.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/main/MainScreen.kt
@@ -94,67 +94,6 @@ fun OrderRow(order: Order) {
     }
 }
 
-@Composable
-fun AddOrderDialog(setShowDialog: (Boolean) -> Unit, onConfirm: (String, String, String) -> Unit) {
-    var orderName by rememberSaveable { mutableStateOf("") }
-    var destinationLatitude by rememberSaveable { mutableStateOf("51.1065859") }
-    var destinationLongitude by rememberSaveable { mutableStateOf("17.0312766") }
-
-    AlertDialog(
-        onDismissRequest = {
-            setShowDialog(false)
-        },
-        title = {
-            Text(
-                modifier = Modifier.padding(8.dp),
-                text = stringResource(id = R.string.add_order_dialog_title)
-            )
-        },
-        confirmButton = {
-            Button(
-                onClick = {
-                    // Change the state to close the dialog
-                    setShowDialog(false)
-                    onConfirm(orderName, destinationLatitude, destinationLongitude)
-                },
-            ) {
-                Text(stringResource(id = R.string.add_order_dialog_confirm_button))
-            }
-        },
-        text = {
-            Column {
-                TextInput(orderName, R.string.add_order_dialog_order_name_hint) { orderName = it }
-                TextInput(
-                    destinationLatitude,
-                    R.string.add_order_dialog_order_latitude_hint
-                ) { destinationLatitude = it }
-                TextInput(
-                    destinationLongitude,
-                    R.string.add_order_dialog_order_longitude_hint
-                ) { destinationLongitude = it }
-            }
-        },
-    )
-}
-
-@Composable
-private fun TextInput(
-    orderName: String,
-    @StringRes labelRes: Int,
-    onValueChange: (String) -> Unit
-) {
-    TextField(
-        modifier = Modifier.padding(8.dp),
-        value = orderName,
-        onValueChange = onValueChange,
-        label = {
-            Text(
-                stringResource(id = labelRes)
-            )
-        }
-    )
-}
-
 @Preview(showBackground = true)
 @Composable
 fun OrderRowPreview() {

--- a/app/src/main/java/com/ably/tracking/demo/publisher/main/MainScreen.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/main/MainScreen.kt
@@ -1,6 +1,5 @@
 package com.ably.tracking.demo.publisher.main
 
-import androidx.annotation.StringRes
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -11,19 +10,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource


### PR DESCRIPTION
This PR disables confirm button when the order name is empty or blank and extracts AddOrderAlertDialog to a separate file

Resolves #28 