### PR TITLE
Redirecting users to app settings on location permission deny

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,5 +97,3 @@ desiredInterval provided in milliseconds
 For the sake of simplicity, the demo app does not handle the following cases:
 
 - keeping Wi-Fi connection awake - when a phone with the rider app running has a locked screen, the OS will disable the Wi-Fi connection to preserve the battery power after some time. If the phone has no other connection to the internet, the tracking will stop. It will resume automatically once the connection is re-established
-- location permission denial - when a user denies the permission app will simply close
-- 

--- a/app/src/main/java/com/ably/tracking/demo/publisher/main/MainActivity.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/main/MainActivity.kt
@@ -2,7 +2,9 @@ package com.ably.tracking.demo.publisher.main
 
 import android.app.AlertDialog
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.annotation.StringRes
@@ -30,7 +32,7 @@ class MainActivity : ComponentActivity() {
         showOkDialog(
             title = R.string.location_permission_denied_dialog_title,
             message = R.string.location_permission_denied_dialog_message,
-            onOk = this::finish
+            onOk = this::navigateToAppSettings
         )
     }
 
@@ -41,5 +43,12 @@ class MainActivity : ComponentActivity() {
             .setPositiveButton(R.string.ok) { _, _ -> onOk() }
             .setCancelable(false)
             .show()
+    }
+
+    private fun navigateToAppSettings() {
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+        val uri: Uri = Uri.fromParts("package", packageName, null)
+        intent.data = uri
+        startActivity(intent)
     }
 }


### PR DESCRIPTION
When a user denies location permission we're showing a dialog and after clicking OK they are redirected to the app settings. There they can grant the app the missing permission 

Resolves #26 