### PR TITLE
Orders api

### DIFF
--- a/app/src/main/java/com/ably/tracking/demo/publisher/KoinModule.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/KoinModule.kt
@@ -15,7 +15,7 @@ import com.ably.tracking.demo.publisher.api.buildOkHttpClient
 import com.ably.tracking.demo.publisher.api.buildRetrofit
 import com.ably.tracking.demo.publisher.common.NotificationProvider
 import com.ably.tracking.demo.publisher.domain.DefaultOrderInteractor
-import com.ably.tracking.demo.publisher.domain.OrderInteractor
+import com.ably.tracking.demo.publisher.domain.OrderManager
 import com.ably.tracking.demo.publisher.secrets.InMemorySecretsManager
 import com.ably.tracking.demo.publisher.secrets.SecretsManager
 import com.ably.tracking.demo.publisher.ui.ActivityNavigator
@@ -71,7 +71,7 @@ val appModule = module {
             BuildConfig.AUTHORIZATION_HEADER_BASE_64,
             Dispatchers.Default
         )
-    } bind OrderInteractor::class
+    } bind OrderManager::class
 
     single { buildOkHttpClient() }
 

--- a/app/src/main/java/com/ably/tracking/demo/publisher/KoinModule.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/KoinModule.kt
@@ -67,7 +67,8 @@ val appModule = module {
         OrderInteractor(
             get(),
             get(),
-            BuildConfig.AUTHORIZATION_HEADER_BASE_64
+            BuildConfig.AUTHORIZATION_HEADER_BASE_64,
+            Dispatchers.Default
         )
     }
 

--- a/app/src/main/java/com/ably/tracking/demo/publisher/KoinModule.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/KoinModule.kt
@@ -14,6 +14,7 @@ import com.ably.tracking.demo.publisher.api.buildDeliveryServiceApi
 import com.ably.tracking.demo.publisher.api.buildOkHttpClient
 import com.ably.tracking.demo.publisher.api.buildRetrofit
 import com.ably.tracking.demo.publisher.common.NotificationProvider
+import com.ably.tracking.demo.publisher.domain.DefaultOrderInteractor
 import com.ably.tracking.demo.publisher.domain.OrderInteractor
 import com.ably.tracking.demo.publisher.secrets.InMemorySecretsManager
 import com.ably.tracking.demo.publisher.secrets.SecretsManager
@@ -64,13 +65,13 @@ val appModule = module {
     single { NotificationProvider(get()) }
 
     single {
-        OrderInteractor(
+        DefaultOrderInteractor(
             get(),
             get(),
             BuildConfig.AUTHORIZATION_HEADER_BASE_64,
             Dispatchers.Default
         )
-    }
+    } bind OrderInteractor::class
 
     single { buildOkHttpClient() }
 

--- a/app/src/main/java/com/ably/tracking/demo/publisher/KoinModule.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/KoinModule.kt
@@ -14,6 +14,7 @@ import com.ably.tracking.demo.publisher.api.buildDeliveryServiceApi
 import com.ably.tracking.demo.publisher.api.buildOkHttpClient
 import com.ably.tracking.demo.publisher.api.buildRetrofit
 import com.ably.tracking.demo.publisher.common.NotificationProvider
+import com.ably.tracking.demo.publisher.domain.OrderInteractor
 import com.ably.tracking.demo.publisher.secrets.InMemorySecretsManager
 import com.ably.tracking.demo.publisher.secrets.SecretsManager
 import com.ably.tracking.demo.publisher.ui.ActivityNavigator
@@ -61,6 +62,14 @@ val appModule = module {
     factory { DefaultFileManager(get()) } bind FileManager::class
 
     single { NotificationProvider(get()) }
+
+    single {
+        OrderInteractor(
+            get(),
+            get(),
+            BuildConfig.AUTHORIZATION_HEADER_BASE_64
+        )
+    }
 
     single { buildOkHttpClient() }
 

--- a/app/src/main/java/com/ably/tracking/demo/publisher/PublisherService.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/PublisherService.kt
@@ -4,8 +4,8 @@ import android.app.Service
 import android.content.Intent
 import android.os.Binder
 import android.os.IBinder
-import com.ably.tracking.demo.publisher.ably.AssetTracker
 import com.ably.tracking.demo.publisher.common.NotificationProvider
+import com.ably.tracking.demo.publisher.domain.OrderInteractor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -18,7 +18,7 @@ class PublisherService : Service() {
 
     private val notificationProvider: NotificationProvider by inject()
 
-    private val assetTracker: AssetTracker by inject()
+    private val orderInteractor: OrderInteractor by inject()
 
     override fun onBind(intent: Intent?): IBinder = Binder()
 
@@ -28,7 +28,7 @@ class PublisherService : Service() {
     }
 
     override fun onDestroy() {
-        scope.launch { assetTracker.disconnect() }
+        scope.launch { orderInteractor.disconnect() }
         super.onDestroy()
     }
 }

--- a/app/src/main/java/com/ably/tracking/demo/publisher/PublisherService.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/PublisherService.kt
@@ -5,7 +5,7 @@ import android.content.Intent
 import android.os.Binder
 import android.os.IBinder
 import com.ably.tracking.demo.publisher.common.NotificationProvider
-import com.ably.tracking.demo.publisher.domain.OrderInteractor
+import com.ably.tracking.demo.publisher.domain.OrderManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -18,7 +18,7 @@ class PublisherService : Service() {
 
     private val notificationProvider: NotificationProvider by inject()
 
-    private val orderInteractor: OrderInteractor by inject()
+    private val orderManager: OrderManager by inject()
 
     override fun onBind(intent: Intent?): IBinder = Binder()
 
@@ -28,7 +28,7 @@ class PublisherService : Service() {
     }
 
     override fun onDestroy() {
-        scope.launch { orderInteractor.disconnect() }
+        scope.launch { orderManager.disconnect() }
         super.onDestroy()
     }
 }

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ably/AssetTracker.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ably/AssetTracker.kt
@@ -7,8 +7,6 @@ import kotlinx.coroutines.flow.StateFlow
 
 interface AssetTracker {
 
-    val isConnected: Boolean
-
     fun connect(): SharedFlow<Set<Trackable>>
 
     suspend fun addTrackable(

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ably/DefaultAssetTracker.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ably/DefaultAssetTracker.kt
@@ -26,7 +26,6 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.runBlocking
 
 class DefaultAssetTracker(
     private val context: Context,

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ably/DefaultAssetTracker.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ably/DefaultAssetTracker.kt
@@ -57,7 +57,7 @@ class DefaultAssetTracker(
             .connection(
                 ConnectionConfiguration(
                     Authentication.jwt(username) {
-                        getAuthorizationToken()
+                        secretsManager.getAblyToken()
                     }
                 )
             ) // provide Ably configuration with credentials
@@ -86,25 +86,20 @@ class DefaultAssetTracker(
             ?.launchIn(coroutineScope)
     }
 
-    private fun getAuthorizationToken(): String =
-        runBlocking {
-            secretsManager.getAblyToken()
-        }
-
     override suspend fun addTrackable(
         trackableId: String,
         destinationLatitude: Double,
         destinationLongitude: Double
     ): StateFlow<TrackableState> =
-            publisher!!.let {
-                val trackable =
-                    Trackable(
-                        id = trackableId,
-                        destination = Destination(destinationLatitude, destinationLongitude),
-                        constraints = getOrderResolutionConstraints()
-                    )
-                it.add(trackable)
-            }
+        publisher!!.let {
+            val trackable =
+                Trackable(
+                    id = trackableId,
+                    destination = Destination(destinationLatitude, destinationLongitude),
+                    constraints = getOrderResolutionConstraints()
+                )
+            it.add(trackable)
+        }
 
     private fun getDefaultResolution() =
         Resolution(Accuracy.BALANCED, desiredInterval = 1_000L, minimumDisplacement = 1_000.0)

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ably/DefaultAssetTracker.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ably/DefaultAssetTracker.kt
@@ -40,9 +40,6 @@ class DefaultAssetTracker(
 
     private var publisher: Publisher? = null
 
-    override val isConnected: Boolean
-        get() = publisher != null
-
     override fun connect(): SharedFlow<Set<Trackable>> {
         if (publisher == null) {
             establishNewConnection()

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ably/DefaultAssetTracker.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ably/DefaultAssetTracker.kt
@@ -96,15 +96,15 @@ class DefaultAssetTracker(
         destinationLatitude: Double,
         destinationLongitude: Double
     ): StateFlow<TrackableState> =
-        publisher!!.let {
-            val trackable =
-                Trackable(
-                    id = trackableId,
-                    destination = Destination(destinationLatitude, destinationLongitude),
-                    constraints = getOrderResolutionConstraints()
-                )
-            it.add(trackable)
-        }
+            publisher!!.let {
+                val trackable =
+                    Trackable(
+                        id = trackableId,
+                        destination = Destination(destinationLatitude, destinationLongitude),
+                        constraints = getOrderResolutionConstraints()
+                    )
+                it.add(trackable)
+            }
 
     private fun getDefaultResolution() =
         Resolution(Accuracy.BALANCED, desiredInterval = 1_000L, minimumDisplacement = 1_000.0)

--- a/app/src/main/java/com/ably/tracking/demo/publisher/api/DeliveryServiceApi.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/api/DeliveryServiceApi.kt
@@ -1,6 +1,5 @@
 package com.ably.tracking.demo.publisher.api
 
-import com.google.gson.JsonObject
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header

--- a/app/src/main/java/com/ably/tracking/demo/publisher/api/DeliveryServiceApi.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/api/DeliveryServiceApi.kt
@@ -1,7 +1,11 @@
 package com.ably.tracking.demo.publisher.api
 
+import com.google.gson.JsonObject
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
+import retrofit2.http.PUT
+import retrofit2.http.Path
 
 interface DeliveryServiceApi {
 
@@ -14,4 +18,16 @@ interface DeliveryServiceApi {
 
     @GET("ably")
     suspend fun getAblyToken(@Header(AUTHORIZATION_HEADER_NAME) authorizationHeader: String): TokenResponse
+
+    @PUT("orders/{orderID}")
+    suspend fun assignOrder(
+        @Header(AUTHORIZATION_HEADER_NAME) authorizationHeader: String,
+        @Path("orderID") orderId: Long
+    )
+
+    @DELETE("orders/{orderID}")
+    suspend fun deleteOrder(
+        @Header(AUTHORIZATION_HEADER_NAME) authorizationHeader: String,
+        @Path("orderID") orderId: Long
+    )
 }

--- a/app/src/main/java/com/ably/tracking/demo/publisher/api/DeliveryServiceApiSource.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/api/DeliveryServiceApiSource.kt
@@ -4,4 +4,8 @@ interface DeliveryServiceApiSource {
     suspend fun getMapboxToken(authBase64: String): String
 
     suspend fun getAblyToken(authBase64: String): String
+
+    suspend fun deleteOrder(authBase64: String, orderId: Long)
+
+    suspend fun assignOrder(authBase64: String, orderId: Long)
 }

--- a/app/src/main/java/com/ably/tracking/demo/publisher/api/RetrofitDeliveryServiceApiSource.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/api/RetrofitDeliveryServiceApiSource.kt
@@ -12,4 +12,10 @@ class RetrofitDeliveryServiceApiSource(private val deliveryServiceApi: DeliveryS
 
     override suspend fun getAblyToken(authBase64: String) =
         deliveryServiceApi.getAblyToken(AUTHORIZATION_HEADER_PREFIX + authBase64).token
+
+    override suspend fun assignOrder(authBase64: String, orderId: Long) =
+        deliveryServiceApi.assignOrder(AUTHORIZATION_HEADER_PREFIX + authBase64, orderId)
+
+    override suspend fun deleteOrder(authBase64: String, orderId: Long) =
+        deliveryServiceApi.deleteOrder(AUTHORIZATION_HEADER_PREFIX + authBase64, orderId)
 }

--- a/app/src/main/java/com/ably/tracking/demo/publisher/common/ListExtensions.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/common/ListExtensions.kt
@@ -1,5 +1,4 @@
 package com.ably.tracking.demo.publisher.common
 
-
 fun <T> List<T>.copyAndReplaceElementAt(index: Int, element: T) =
     subList(0, index) + element + subList(index, size - 1)

--- a/app/src/main/java/com/ably/tracking/demo/publisher/common/ListExtensions.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/common/ListExtensions.kt
@@ -1,4 +1,4 @@
 package com.ably.tracking.demo.publisher.common
 
 fun <T> List<T>.copyAndReplaceElementAt(index: Int, element: T) =
-    subList(0, index) + element + subList(index, size - 1)
+    subList(0, index) + element + subList(index, size)

--- a/app/src/main/java/com/ably/tracking/demo/publisher/common/ListExtensions.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/common/ListExtensions.kt
@@ -1,0 +1,5 @@
+package com.ably.tracking.demo.publisher.common
+
+
+fun <T> List<T>.copyAndReplaceElementAt(index: Int, element: T) =
+    subList(0, index) + element + subList(index, size - 1)

--- a/app/src/main/java/com/ably/tracking/demo/publisher/common/ListExtensions.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/common/ListExtensions.kt
@@ -1,4 +1,4 @@
 package com.ably.tracking.demo.publisher.common
 
 fun <T> List<T>.copyAndReplaceElementAt(index: Int, element: T) =
-    subList(0, index) + element + subList(index, size)
+    subList(0, index) + element + subList(index + 1, size)

--- a/app/src/main/java/com/ably/tracking/demo/publisher/common/TrackableStateExtensions.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/common/TrackableStateExtensions.kt
@@ -1,13 +1,11 @@
 package com.ably.tracking.demo.publisher.common
 
-import androidx.annotation.StringRes
 import com.ably.tracking.TrackableState
-import com.ably.tracking.demo.publisher.R
+import com.ably.tracking.demo.publisher.domain.OrderState
 
-@StringRes
-fun TrackableState.toStringRes(): Int = when (this) {
-    is TrackableState.Online -> R.string.trackable_state_online
-    is TrackableState.Publishing -> R.string.trackable_state_publishing
-    is TrackableState.Failed -> R.string.trackable_state_failed
-    is TrackableState.Offline -> R.string.trackable_state_offline
+fun TrackableState.toOrderState(): OrderState = when (this) {
+    is TrackableState.Online -> OrderState.Online
+    is TrackableState.Publishing -> OrderState.Publishing
+    is TrackableState.Failed -> OrderState.Failed
+    is TrackableState.Offline -> OrderState.Offline
 }

--- a/app/src/main/java/com/ably/tracking/demo/publisher/domain/Order.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/domain/Order.kt
@@ -1,0 +1,13 @@
+package com.ably.tracking.demo.publisher.domain
+
+data class Order(
+    val id: String,
+    val state: OrderState,
+)
+
+enum class OrderState {
+    Online,
+    Publishing,
+    Failed,
+    Offline
+}

--- a/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderInteractor.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderInteractor.kt
@@ -2,14 +2,14 @@ package com.ably.tracking.demo.publisher.domain
 
 import com.ably.tracking.TrackableState
 import com.ably.tracking.demo.publisher.ably.AssetTracker
-import com.ably.tracking.demo.publisher.api.DeliveryServiceApi
+import com.ably.tracking.demo.publisher.api.DeliveryServiceDataSource
 import com.ably.tracking.publisher.Trackable
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class OrderInteractor(
     private val assetTracker: AssetTracker,
-    private val deliveryServiceApi: DeliveryServiceApi,
+    private val deliveryServiceDataSource: DeliveryServiceDataSource,
     private val authorizationHeaderBase64: String
 ) {
 
@@ -21,7 +21,7 @@ class OrderInteractor(
         destinationLatitude: Double,
         destinationLongitude: Double
     ): StateFlow<TrackableState> {
-        deliveryServiceApi.assignOrder(authorizationHeaderBase64, trackableId.toLong())
+        deliveryServiceDataSource.assignOrder(authorizationHeaderBase64, trackableId.toLong())
         return assetTracker.addTrackable(trackableId, destinationLatitude, destinationLongitude)
     }
 

--- a/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderInteractor.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderInteractor.kt
@@ -2,14 +2,14 @@ package com.ably.tracking.demo.publisher.domain
 
 import com.ably.tracking.TrackableState
 import com.ably.tracking.demo.publisher.ably.AssetTracker
-import com.ably.tracking.demo.publisher.api.DeliveryServiceApiSource
+import com.ably.tracking.demo.publisher.api.DeliveryServiceApi
 import com.ably.tracking.publisher.Trackable
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class OrderInteractor(
     private val assetTracker: AssetTracker,
-    private val apiSource: DeliveryServiceApiSource,
+    private val deliveryServiceApi: DeliveryServiceApi,
     private val authorizationHeaderBase64: String
 ) {
 
@@ -21,7 +21,7 @@ class OrderInteractor(
         destinationLatitude: Double,
         destinationLongitude: Double
     ): StateFlow<TrackableState> {
-        apiSource.assignOrder(authorizationHeaderBase64, trackableId.toLong())
+        deliveryServiceApi.assignOrder(authorizationHeaderBase64, trackableId.toLong())
         return assetTracker.addTrackable(trackableId, destinationLatitude, destinationLongitude)
     }
 

--- a/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderInteractor.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderInteractor.kt
@@ -3,35 +3,111 @@ package com.ably.tracking.demo.publisher.domain
 import com.ably.tracking.TrackableState
 import com.ably.tracking.demo.publisher.ably.AssetTracker
 import com.ably.tracking.demo.publisher.api.DeliveryServiceDataSource
+import com.ably.tracking.demo.publisher.common.toOrderState
 import com.ably.tracking.publisher.Trackable
-import kotlinx.coroutines.flow.SharedFlow
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 
 class OrderInteractor(
     private val assetTracker: AssetTracker,
     private val deliveryServiceDataSource: DeliveryServiceDataSource,
-    private val authorizationHeaderBase64: String
-) {
+    private val authorizationHeaderBase64: String,
+    coroutineDispatcher: CoroutineDispatcher
+) : CoroutineScope {
+
+    override val coroutineContext: CoroutineContext = SupervisorJob() + coroutineDispatcher
+
+    private val trackableStateFlows = mutableMapOf<String, StateFlow<TrackableState>>()
+
+    val orders: MutableStateFlow<List<Order>> = MutableStateFlow(emptyList())
+
+    fun connect() {
+        launch {
+            assetTracker.connect().map { it.mapToOrders() }
+                .collect { trackables ->
+                    updateOrders { trackables }
+                }
+        }
+    }
+
+    private fun Set<Trackable>.mapToOrders() =
+        map {
+            Order(
+                id = it.id,
+                state = it.getState().toOrderState(),
+            )
+        }
 
 
-    fun connect(): SharedFlow<Set<Trackable>> = assetTracker.connect()
+    private fun Trackable.getState(): TrackableState {
+        val trackableStateFlow = trackableStateFlows[id] ?: getTrackableState(id)
+        return trackableStateFlow?.value ?: TrackableState.Offline()
+    }
 
     suspend fun addTrackable(
         trackableId: String,
         destinationLatitude: Double,
         destinationLongitude: Double
-    ): StateFlow<TrackableState> {
+    ) {
         deliveryServiceDataSource.assignOrder(authorizationHeaderBase64, trackableId.toLong())
-        return assetTracker.addTrackable(trackableId, destinationLatitude, destinationLongitude)
+        addOrder(trackableId, destinationLatitude, destinationLongitude)
     }
+
+    private suspend fun addOrder(
+        trackableId: String,
+        destinationLatitude: Double,
+        destinationLongitude: Double
+    ) {
+        val trackableStateFlow =
+            assetTracker.addTrackable(trackableId, destinationLatitude, destinationLongitude)
+
+        trackableStateFlows[trackableId] = trackableStateFlow
+
+        trackableStateFlow
+            .onEach { state ->
+                updateOrders { it.updateOrders(trackableId, state) }
+            }
+            .launchIn(this)
+    }
+
+    private fun List<Order>.updateOrders(
+        orderId: String,
+        state: TrackableState
+    ): List<Order> {
+        val orderIndex = indexOfFirst { order -> order.id == orderId }
+        return if (orderIndex == -1) {
+            this
+        } else {
+            val updatedOrder = this[orderIndex].copy(state = state.toOrderState())
+            copyAndReplaceOrderAt(orderIndex, updatedOrder)
+        }
+    }
+
+    private fun List<Order>.copyAndReplaceOrderAt(index: Int, order: Order) =
+        subList(0, index) + order + subList(index, size - 1)
+
+    private suspend fun updateOrders(update: (List<Order>) -> List<Order>) {
+        orders.emit(update(orders.value))
+    }
+
+    private fun getTrackableState(trackableId: String): StateFlow<TrackableState>? =
+        assetTracker.getTrackableState(trackableId)
 
     suspend fun track(trackableId: String) = assetTracker.track(trackableId)
 
-    fun getTrackableState(trackableId: String): StateFlow<TrackableState>? =
-        assetTracker.getTrackableState(trackableId)
-
-    suspend fun remove(trackableId: String) = assetTracker.remove(trackableId)
+    suspend fun remove(trackableId: String) {
+        assetTracker.remove(trackableId)
+        trackableStateFlows.remove(trackableId)
+    }
 
     suspend fun disconnect() = assetTracker.disconnect()
-
 }

--- a/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderInteractor.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderInteractor.kt
@@ -3,6 +3,7 @@ package com.ably.tracking.demo.publisher.domain
 import com.ably.tracking.TrackableState
 import com.ably.tracking.demo.publisher.ably.AssetTracker
 import com.ably.tracking.demo.publisher.api.DeliveryServiceDataSource
+import com.ably.tracking.demo.publisher.common.copyAndReplaceElementAt
 import com.ably.tracking.demo.publisher.common.toOrderState
 import com.ably.tracking.publisher.Trackable
 import kotlin.coroutines.CoroutineContext
@@ -108,12 +109,9 @@ class DefaultOrderInteractor(
             this
         } else {
             val updatedOrder = this[orderIndex].copy(state = state.toOrderState())
-            copyAndReplaceOrderAt(orderIndex, updatedOrder)
+            copyAndReplaceElementAt(orderIndex, updatedOrder)
         }
     }
-
-    private fun List<Order>.copyAndReplaceOrderAt(index: Int, order: Order) =
-        subList(0, index) + order + subList(index, size - 1)
 
     private suspend fun updateOrders(update: (List<Order>) -> List<Order>) {
         orders.emit(update(orders.value))

--- a/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderInteractor.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderInteractor.kt
@@ -1,0 +1,37 @@
+package com.ably.tracking.demo.publisher.domain
+
+import com.ably.tracking.TrackableState
+import com.ably.tracking.demo.publisher.ably.AssetTracker
+import com.ably.tracking.demo.publisher.api.DeliveryServiceApiSource
+import com.ably.tracking.publisher.Trackable
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class OrderInteractor(
+    private val assetTracker: AssetTracker,
+    private val apiSource: DeliveryServiceApiSource,
+    private val authorizationHeaderBase64: String
+) {
+
+
+    fun connect(): SharedFlow<Set<Trackable>> = assetTracker.connect()
+
+    suspend fun addTrackable(
+        trackableId: String,
+        destinationLatitude: Double,
+        destinationLongitude: Double
+    ): StateFlow<TrackableState> {
+        apiSource.assignOrder(authorizationHeaderBase64, trackableId.toLong())
+        return assetTracker.addTrackable(trackableId, destinationLatitude, destinationLongitude)
+    }
+
+    suspend fun track(trackableId: String) = assetTracker.track(trackableId)
+
+    fun getTrackableState(trackableId: String): StateFlow<TrackableState>? =
+        assetTracker.getTrackableState(trackableId)
+
+    suspend fun remove(trackableId: String) = assetTracker.remove(trackableId)
+
+    suspend fun disconnect() = assetTracker.disconnect()
+
+}

--- a/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderInteractor.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderInteractor.kt
@@ -34,7 +34,6 @@ interface OrderInteractor {
     suspend fun removeOrder(orderId: String)
 
     suspend fun disconnect()
-
 }
 
 class DefaultOrderInteractor(
@@ -67,12 +66,10 @@ class DefaultOrderInteractor(
             )
         }
 
-
     private fun Trackable.getState(): TrackableState {
         val trackableStateFlow = trackableStateFlows[id] ?: getTrackableState(id)
         return trackableStateFlow?.value ?: TrackableState.Offline()
     }
-
 
     override suspend fun assignOrder(
         orderId: String,

--- a/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderManager.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderManager.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 interface OrderManager {
-    val orders: MutableStateFlow<List<Order>>
+    val orders: StateFlow<List<Order>>
 
     fun connect()
 

--- a/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderManager.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderManager.kt
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
-interface OrderInteractor {
+interface OrderManager {
     val orders: MutableStateFlow<List<Order>>
 
     fun connect()
@@ -41,7 +41,7 @@ class DefaultOrderInteractor(
     private val deliveryServiceDataSource: DeliveryServiceDataSource,
     private val authorizationHeaderBase64: String,
     coroutineDispatcher: CoroutineDispatcher
-) : OrderInteractor, CoroutineScope {
+) : OrderManager, CoroutineScope {
 
     override val coroutineContext: CoroutineContext = SupervisorJob() + coroutineDispatcher
 

--- a/app/src/main/java/com/ably/tracking/demo/publisher/secrets/InMemorySecretsManager.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/secrets/InMemorySecretsManager.kt
@@ -10,19 +10,17 @@ class InMemorySecretsManager(
 
     companion object {
         private const val MAPBOX_TOKEN_KEY = "mapbox"
-        private const val ALBY_TOKEN_KEY = "ably"
     }
 
     private val secrets = mutableMapOf<String, String>()
 
     override suspend fun loadSecrets() {
         secrets[MAPBOX_TOKEN_KEY] = deliveryServiceApiSource.getMapboxToken(authBase64)
-        secrets[ALBY_TOKEN_KEY] = deliveryServiceApiSource.getAblyToken(authBase64)
     }
 
     override fun getUsername(): String = authUsername
 
     override fun getMapboxToken(): String = secrets[MAPBOX_TOKEN_KEY] ?: ""
 
-    override fun getAblyToken(): String = secrets[ALBY_TOKEN_KEY] ?: ""
+    override suspend fun getAblyToken(): String = deliveryServiceApiSource.getAblyToken(authBase64)
 }

--- a/app/src/main/java/com/ably/tracking/demo/publisher/secrets/SecretsManager.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/secrets/SecretsManager.kt
@@ -4,5 +4,5 @@ interface SecretsManager {
     suspend fun loadSecrets()
     fun getUsername(): String
     fun getMapboxToken(): String
-    fun getAblyToken(): String
+    suspend fun getAblyToken(): String
 }

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainScreen.kt
@@ -77,7 +77,7 @@ fun MainScreenContent(state: MainScreenState, onAddTrackable: (String, String, S
 }
 
 @Composable
-fun OrderRow(order: Order) {
+fun OrderRow(order: OrderViewItem) {
     Row(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
@@ -97,7 +97,7 @@ fun OrderRow(order: Order) {
 @Preview(showBackground = true)
 @Composable
 fun OrderRowPreview() {
-    val order = Order(name = "Burger", R.string.trackable_state_online, {}, {})
+    val order = OrderViewItem(name = "Burger", R.string.trackable_state_online, {}, {})
     OrderRow(order = order)
 }
 
@@ -106,9 +106,9 @@ fun OrderRowPreview() {
 fun MainScreenContentPreview() {
     val state = MainScreenState(
         listOf(
-            Order(name = "Burger", R.string.trackable_state_online, {}, {}),
-            Order(name = "Pizza", R.string.trackable_state_offline, {}, {}),
-            Order(name = "Sushi", R.string.trackable_state_publishing, {}, {})
+            OrderViewItem(name = "Burger", R.string.trackable_state_online, {}, {}),
+            OrderViewItem(name = "Pizza", R.string.trackable_state_offline, {}, {}),
+            OrderViewItem(name = "Sushi", R.string.trackable_state_publishing, {}, {})
         )
     )
     MainScreenContent(state) { _, _, _ -> }

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainScreenState.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainScreenState.kt
@@ -1,3 +1,3 @@
 package com.ably.tracking.demo.publisher.ui.main
 
-data class MainScreenState(val orders: List<Order> = emptyList())
+data class MainScreenState(val orders: List<OrderViewItem> = emptyList())

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainViewModel.kt
@@ -69,17 +69,17 @@ class MainViewModel(
     }
 
     private fun onTrackCLicked(trackableId: String) = launch {
-        orderInteractor.track(trackableId)
+        orderInteractor.pickUpOrder(trackableId)
     }
 
     private fun onRemoveClicked(trackableId: String) = launch {
-        orderInteractor.remove(trackableId)
+        orderInteractor.removeOrder(trackableId)
         trackableStates.remove(trackableId)
     }
 
     fun addOrder(orderName: String, destinationLatitude: String, destinationLongitude: String) =
         launch {
-            orderInteractor.addTrackable(
+            orderInteractor.assignOrder(
                 orderName,
                 destinationLatitude.toDouble(),
                 destinationLongitude.toDouble()

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainViewModel.kt
@@ -1,8 +1,6 @@
 package com.ably.tracking.demo.publisher.ui.main
 
 import com.ably.tracking.TrackableState
-import com.ably.tracking.demo.publisher.ably.AssetTracker
-import com.ably.tracking.demo.publisher.api.DeliveryServiceApiSource
 import com.ably.tracking.demo.publisher.common.BaseViewModel
 import com.ably.tracking.demo.publisher.common.toStringRes
 import com.ably.tracking.demo.publisher.domain.OrderInteractor

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainViewModel.kt
@@ -5,7 +5,7 @@ import com.ably.tracking.TrackableState
 import com.ably.tracking.demo.publisher.R
 import com.ably.tracking.demo.publisher.common.BaseViewModel
 import com.ably.tracking.demo.publisher.domain.Order
-import com.ably.tracking.demo.publisher.domain.OrderInteractor
+import com.ably.tracking.demo.publisher.domain.OrderManager
 import com.ably.tracking.demo.publisher.domain.OrderState
 import com.ably.tracking.demo.publisher.ui.Navigator
 import kotlinx.coroutines.CoroutineDispatcher
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 class MainViewModel(
-    private val orderInteractor: OrderInteractor,
+    private val orderManager: OrderManager,
     private val navigator: Navigator,
     coroutineScope: CoroutineDispatcher
 ) :
@@ -28,7 +28,7 @@ class MainViewModel(
 
     init {
         launch {
-            orderInteractor.orders
+            orderManager.orders
                 .map { it.mapToViewItems() }
                 .collect { orders ->
                     updateState {
@@ -65,21 +65,21 @@ class MainViewModel(
     }
 
     fun onLocationPermissionGranted() = launch {
-        orderInteractor.connect()
+        orderManager.connect()
     }
 
     private fun onTrackCLicked(trackableId: String) = launch {
-        orderInteractor.pickUpOrder(trackableId)
+        orderManager.pickUpOrder(trackableId)
     }
 
     private fun onRemoveClicked(trackableId: String) = launch {
-        orderInteractor.removeOrder(trackableId)
+        orderManager.removeOrder(trackableId)
         trackableStates.remove(trackableId)
     }
 
     fun addOrder(orderName: String, destinationLatitude: String, destinationLongitude: String) =
         launch {
-            orderInteractor.assignOrder(
+            orderManager.assignOrder(
                 orderName,
                 destinationLatitude.toDouble(),
                 destinationLongitude.toDouble()

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainViewModel.kt
@@ -2,8 +2,10 @@ package com.ably.tracking.demo.publisher.ui.main
 
 import com.ably.tracking.TrackableState
 import com.ably.tracking.demo.publisher.ably.AssetTracker
+import com.ably.tracking.demo.publisher.api.DeliveryServiceApiSource
 import com.ably.tracking.demo.publisher.common.BaseViewModel
 import com.ably.tracking.demo.publisher.common.toStringRes
+import com.ably.tracking.demo.publisher.domain.OrderInteractor
 import com.ably.tracking.demo.publisher.ui.Navigator
 import com.ably.tracking.publisher.Trackable
 import kotlinx.coroutines.CoroutineDispatcher
@@ -16,7 +18,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 class MainViewModel(
-    private val assetTracker: AssetTracker,
+    private val orderInteractor: OrderInteractor,
     private val navigator: Navigator,
     coroutineScope: CoroutineDispatcher
 ) :
@@ -27,7 +29,7 @@ class MainViewModel(
     private val trackableStates = mutableMapOf<String, StateFlow<TrackableState>>()
 
     fun onLocationPermissionGranted() = launch {
-        assetTracker.connect()
+        orderInteractor.connect()
             .map { it.mapToOrders() }
             .collect { trackables ->
                 updateState {
@@ -51,22 +53,22 @@ class MainViewModel(
         }
 
     private fun Trackable.getState(): TrackableState {
-        val trackableStateFlow = trackableStates[id] ?: assetTracker.getTrackableState(id)
+        val trackableStateFlow = trackableStates[id] ?: orderInteractor.getTrackableState(id)
         return trackableStateFlow?.value ?: TrackableState.Offline()
     }
 
     private fun onTrackCLicked(trackableId: String) = launch {
-        assetTracker.track(trackableId)
+        orderInteractor.track(trackableId)
     }
 
     private fun onRemoveClicked(trackableId: String) = launch {
-        assetTracker.remove(trackableId)
+        orderInteractor.remove(trackableId)
         trackableStates.remove(trackableId)
     }
 
     fun addOrder(orderName: String, destinationLatitude: String, destinationLongitude: String) =
         launch {
-            val trackableStateFlow = assetTracker.addTrackable(
+            val trackableStateFlow = orderInteractor.addTrackable(
                 orderName,
                 destinationLatitude.toDouble(),
                 destinationLongitude.toDouble()

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/OrderViewItem.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/OrderViewItem.kt
@@ -2,7 +2,7 @@ package com.ably.tracking.demo.publisher.ui.main
 
 import androidx.annotation.StringRes
 
-data class Order(
+data class OrderViewItem(
     val name: String,
     @StringRes val state: Int,
     val onTrackClicked: () -> Unit,

--- a/app/src/test/java/com/ably/tracking/demo/publisher/ably/FakeAssetTracker.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/ably/FakeAssetTracker.kt
@@ -8,18 +8,13 @@ import kotlinx.coroutines.flow.StateFlow
 
 class FakeAssetTracker : AssetTracker {
 
-    override var isConnected: Boolean = false
-
     val trackableStates = mutableMapOf<String, MutableStateFlow<TrackableState>>()
 
     var trackedTrackableId: String? = null
 
     val trackables = MutableStateFlow(emptySet<Trackable>())
 
-    override fun connect(): SharedFlow<Set<Trackable>> {
-        isConnected = true
-        return trackables
-    }
+    override fun connect(): SharedFlow<Set<Trackable>> = trackables
 
     override suspend fun addTrackable(
         trackableId: String,
@@ -46,6 +41,6 @@ class FakeAssetTracker : AssetTracker {
     }
 
     override suspend fun disconnect() {
-        isConnected = false
+        // no-op
     }
 }

--- a/app/src/test/java/com/ably/tracking/demo/publisher/api/FakeDeliveryServiceApiSource.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/api/FakeDeliveryServiceApiSource.kt
@@ -9,4 +9,12 @@ class FakeDeliveryServiceApiSource : DeliveryServiceApiSource {
     override suspend fun getMapboxToken(authBase64: String): String = mapboxToken
 
     override suspend fun getAblyToken(authBase64: String): String = ablyToken
+
+    override suspend fun deleteOrder(authBase64: String, orderId: Long) {
+        // no-op
+    }
+
+    override suspend fun assignOrder(authBase64: String, orderId: Long) {
+        // no-op
+    }
 }

--- a/app/src/test/java/com/ably/tracking/demo/publisher/api/RetrofitDeliveryServiceApiSourceTest.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/api/RetrofitDeliveryServiceApiSourceTest.kt
@@ -45,4 +45,28 @@ internal class RetrofitDeliveryServiceApiSourceTest {
         assertThat(ablyToken)
             .isNotEmpty()
     }
+
+    @Test
+    fun `call to assignOrder returns non-empty value`() = runTest {
+        // given
+
+        // when
+        val result = deliveryServiceApiSource.assignOrder(authorizationHeader, 5)
+
+        // then
+        assertThat(result)
+            .isNotNull()
+    }
+
+    @Test
+    fun `call to deleteOrder returns non-empty value`() = runTest {
+        // given
+
+        // when
+        val result = deliveryServiceApiSource.deleteOrder(authorizationHeader, 5)
+
+        // then
+        assertThat(result)
+            .isNotNull()
+    }
 }

--- a/app/src/test/java/com/ably/tracking/demo/publisher/common/ListExtensionsKtTest.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/common/ListExtensionsKtTest.kt
@@ -1,0 +1,22 @@
+package com.ably.tracking.demo.publisher.common
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@ExperimentalCoroutinesApi
+internal class ListExtensionsKtTest {
+
+    @Test
+    fun `copyAndReplaceElementAt should alter only element at provided index`() = runTest {
+        // given
+        val input = listOf(1, 2, 3, 4, 5, 6)
+
+        // when
+        val output = input.copyAndReplaceElementAt(index = 2, element = 9)
+
+        // then
+        assertThat(output).isEqualTo(listOf(1, 2, 9, 3, 4, 5, 6))
+    }
+}

--- a/app/src/test/java/com/ably/tracking/demo/publisher/common/ListExtensionsKtTest.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/common/ListExtensionsKtTest.kt
@@ -17,6 +17,6 @@ internal class ListExtensionsKtTest {
         val output = input.copyAndReplaceElementAt(index = 2, element = 9)
 
         // then
-        assertThat(output).isEqualTo(listOf(1, 2, 9, 3, 4, 5, 6))
+        assertThat(output).isEqualTo(listOf(1, 2, 9, 4, 5, 6))
     }
 }

--- a/app/src/test/java/com/ably/tracking/demo/publisher/domain/FakeOrderInteractor.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/domain/FakeOrderInteractor.kt
@@ -3,7 +3,7 @@ package com.ably.tracking.demo.publisher.domain
 import com.ably.tracking.demo.publisher.common.copyAndReplaceElementAt
 import kotlinx.coroutines.flow.MutableStateFlow
 
-class FakeOrderInteractor : OrderInteractor {
+class FakeOrderInteractor : OrderManager {
 
     override val orders: MutableStateFlow<List<Order>> = MutableStateFlow(emptyList())
 

--- a/app/src/test/java/com/ably/tracking/demo/publisher/domain/FakeOrderInteractor.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/domain/FakeOrderInteractor.kt
@@ -1,0 +1,46 @@
+package com.ably.tracking.demo.publisher.domain
+
+import com.ably.tracking.demo.publisher.common.copyAndReplaceElementAt
+import kotlinx.coroutines.flow.MutableStateFlow
+
+class FakeOrderInteractor : OrderInteractor {
+
+    override val orders: MutableStateFlow<List<Order>> = MutableStateFlow(emptyList())
+
+    var trackedOrderId: String? = null
+
+    override fun connect() {
+        // no-op
+    }
+
+    override suspend fun assignOrder(
+        orderId: String,
+        destinationLatitude: Double,
+        destinationLongitude: Double
+    ) {
+        orders.emit(orders.value.plus(Order(orderId, OrderState.Offline)))
+    }
+
+    suspend fun updateOrderState(orderId: String, orderState: OrderState) {
+        val ordersList = orders.value
+        val orderIndex = ordersList.indexOfFirst { it.id == orderId }
+        val updatedOrder = ordersList[orderIndex].copy(state = orderState)
+
+        orders.emit(
+            ordersList.copyAndReplaceElementAt(orderIndex, updatedOrder)
+        )
+    }
+
+    override suspend fun pickUpOrder(orderId: String) {
+        trackedOrderId = orderId
+    }
+
+    override suspend fun removeOrder(orderId: String) {
+        val order = orders.value.first { it.id == orderId }
+        orders.emit(orders.value.minus(order))
+    }
+
+    override suspend fun disconnect() {
+        // no-op
+    }
+}

--- a/app/src/test/java/com/ably/tracking/demo/publisher/secrets/FakeSecretsManager.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/secrets/FakeSecretsManager.kt
@@ -20,5 +20,5 @@ class FakeSecretsManager : SecretsManager {
 
     override fun getMapboxToken() = mapboxTokenValue!!
 
-    override fun getAblyToken() = ablyTokenValue!!
+    override suspend fun getAblyToken() = ablyTokenValue!!
 }

--- a/app/src/test/java/com/ably/tracking/demo/publisher/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/ui/main/MainViewModelTest.kt
@@ -4,6 +4,7 @@ import com.ably.tracking.TrackableState
 import com.ably.tracking.demo.publisher.BaseViewModelTest
 import com.ably.tracking.demo.publisher.R
 import com.ably.tracking.demo.publisher.ably.FakeAssetTracker
+import com.ably.tracking.demo.publisher.domain.OrderInteractor
 import com.ably.tracking.demo.publisher.ui.FakeNavigator
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/app/src/test/java/com/ably/tracking/demo/publisher/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/ui/main/MainViewModelTest.kt
@@ -1,10 +1,9 @@
 package com.ably.tracking.demo.publisher.ui.main
 
-import com.ably.tracking.TrackableState
 import com.ably.tracking.demo.publisher.BaseViewModelTest
 import com.ably.tracking.demo.publisher.R
-import com.ably.tracking.demo.publisher.ably.FakeAssetTracker
-import com.ably.tracking.demo.publisher.domain.OrderInteractor
+import com.ably.tracking.demo.publisher.domain.FakeOrderInteractor
+import com.ably.tracking.demo.publisher.domain.OrderState
 import com.ably.tracking.demo.publisher.ui.FakeNavigator
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -17,11 +16,11 @@ internal class MainViewModelTest : BaseViewModelTest() {
     private val destinationLatitude = "51.1065859"
     private val destinationLongitude = "17.0312766"
 
-    private val assetTracker = FakeAssetTracker()
-
     private val navigator = FakeNavigator()
 
-    private val viewModel = MainViewModel(assetTracker, navigator, baseTestCoroutineDispatcher)
+    private val orderInteractor = FakeOrderInteractor()
+
+    private val viewModel = MainViewModel(orderInteractor, navigator, baseTestCoroutineDispatcher)
 
     @Test
     fun `after calling add on view model new order is created`() = runTest {
@@ -47,7 +46,7 @@ internal class MainViewModelTest : BaseViewModelTest() {
             viewModel.addOrder(orderName, destinationLatitude, destinationLongitude)
 
             // when
-            assetTracker.trackableStates[orderName]?.emit(TrackableState.Publishing)
+            orderInteractor.updateOrderState(orderName, OrderState.Publishing)
 
             // then
             val order = viewModel.state.value.orders.first { it.name == orderName }
@@ -66,7 +65,7 @@ internal class MainViewModelTest : BaseViewModelTest() {
             viewModel.state.value.orders.first().onTrackClicked()
 
             // then
-            assertThat(assetTracker.trackedTrackableId).isEqualTo(orderName)
+            assertThat(orderInteractor.trackedOrderId).isEqualTo(orderName)
         }
 
     @Test
@@ -81,7 +80,6 @@ internal class MainViewModelTest : BaseViewModelTest() {
             viewModel.state.value.orders.first().onRemoveClicked()
 
             // then
-            assertThat(assetTracker.trackableStates[orderName]).isNull()
             assertThat(viewModel.state.value.orders).isEmpty()
         }
 }


### PR DESCRIPTION
This PR implements the second step of #38 - integrating with order API backend
When creating new classes went with desired naming (`order` instead of `trackable`) but didn't change it across the app as it is in the scope of #14