### PR TITLE
unused latitude and longitude inputs removed from create order dialog

### DIFF
--- a/app/src/main/java/com/ably/tracking/demo/publisher/api/ApiDeliveryServiceDataSource.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/api/ApiDeliveryServiceDataSource.kt
@@ -14,7 +14,7 @@ class ApiDeliveryServiceDataSource(private val deliveryServiceApi: DeliveryServi
         deliveryServiceApi.getAblyToken(AUTHORIZATION_HEADER_PREFIX + authBase64).token
 
     override suspend fun assignOrder(authBase64: String, orderId: Long) =
-        deliveryServiceApi.assignOrder(AUTHORIZATION_HEADER_PREFIX + authBase64, orderId)
+        deliveryServiceApi.assignOrder(AUTHORIZATION_HEADER_PREFIX + authBase64, orderId).to
 
     override suspend fun deleteOrder(authBase64: String, orderId: Long) =
         deliveryServiceApi.deleteOrder(AUTHORIZATION_HEADER_PREFIX + authBase64, orderId)

--- a/app/src/main/java/com/ably/tracking/demo/publisher/api/ApiDeliveryServiceDataSource.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/api/ApiDeliveryServiceDataSource.kt
@@ -14,7 +14,10 @@ class ApiDeliveryServiceDataSource(private val deliveryServiceApi: DeliveryServi
         deliveryServiceApi.getAblyToken(AUTHORIZATION_HEADER_PREFIX + authBase64).token
 
     override suspend fun assignOrder(authBase64: String, orderId: Long) =
-        deliveryServiceApi.assignOrder(AUTHORIZATION_HEADER_PREFIX + authBase64, orderId).to
+        deliveryServiceApi.assignOrder(
+            AUTHORIZATION_HEADER_PREFIX + authBase64,
+            orderId
+        ).destination
 
     override suspend fun deleteOrder(authBase64: String, orderId: Long) =
         deliveryServiceApi.deleteOrder(AUTHORIZATION_HEADER_PREFIX + authBase64, orderId)

--- a/app/src/main/java/com/ably/tracking/demo/publisher/api/DeliveryServiceApi.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/api/DeliveryServiceApi.kt
@@ -22,7 +22,7 @@ interface DeliveryServiceApi {
     suspend fun assignOrder(
         @Header(AUTHORIZATION_HEADER_NAME) authorizationHeader: String,
         @Path("orderID") orderId: Long
-    )
+    ): OrderResponse
 
     @DELETE("orders/{orderID}")
     suspend fun deleteOrder(

--- a/app/src/main/java/com/ably/tracking/demo/publisher/api/DeliveryServiceDataSource.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/api/DeliveryServiceDataSource.kt
@@ -5,7 +5,7 @@ interface DeliveryServiceDataSource {
 
     suspend fun getAblyToken(authBase64: String): String
 
-    suspend fun deleteOrder(authBase64: String, orderId: Long)
+    suspend fun assignOrder(authBase64: String, orderId: Long): Destination
 
-    suspend fun assignOrder(authBase64: String, orderId: Long)
+    suspend fun deleteOrder(authBase64: String, orderId: Long)
 }

--- a/app/src/main/java/com/ably/tracking/demo/publisher/api/OrderResponse.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/api/OrderResponse.kt
@@ -1,7 +1,9 @@
 package com.ably.tracking.demo.publisher.api
 
+import com.google.gson.annotations.SerializedName
+
 data class OrderResponse(
-    val to: Destination
+    @SerializedName("to") val destination: Destination
 )
 
 data class Destination(

--- a/app/src/main/java/com/ably/tracking/demo/publisher/api/OrderResponse.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/api/OrderResponse.kt
@@ -1,0 +1,10 @@
+package com.ably.tracking.demo.publisher.api
+
+data class OrderResponse(
+    val to: Destination
+)
+
+data class Destination(
+    val latitude: Double,
+    val longitude: Double
+)

--- a/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderManager.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/domain/OrderManager.kt
@@ -24,11 +24,7 @@ interface OrderManager {
 
     fun connect()
 
-    suspend fun assignOrder(
-        orderId: String,
-        destinationLatitude: Double,
-        destinationLongitude: Double
-    )
+    suspend fun assignOrder(orderId: String)
 
     suspend fun pickUpOrder(orderId: String)
 
@@ -72,13 +68,12 @@ class DefaultOrderInteractor(
         return trackableStateFlow?.value ?: TrackableState.Offline()
     }
 
-    override suspend fun assignOrder(
-        orderId: String,
-        destinationLatitude: Double,
-        destinationLongitude: Double
-    ) {
-        deliveryServiceDataSource.assignOrder(secretsManager.getAuthorizationHeader()!!, orderId.toLong())
-        addOrder(orderId, destinationLatitude, destinationLongitude)
+    override suspend fun assignOrder(orderId: String) {
+        val destination = deliveryServiceDataSource.assignOrder(
+            secretsManager.getAuthorizationHeader()!!,
+            orderId.toLong()
+        )
+        addOrder(orderId, destination.latitude, destination.longitude)
     }
 
     private suspend fun addOrder(

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/AddOrderDialog.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/AddOrderDialog.kt
@@ -18,10 +18,8 @@ import androidx.compose.ui.unit.dp
 import com.ably.tracking.demo.publisher.R
 
 @Composable
-fun AddOrderDialog(setShowDialog: (Boolean) -> Unit, onConfirm: (String, String, String) -> Unit) {
+fun AddOrderDialog(setShowDialog: (Boolean) -> Unit, onConfirm: (String) -> Unit) {
     var orderName by rememberSaveable { mutableStateOf("") }
-    var destinationLatitude by rememberSaveable { mutableStateOf("51.1065859") }
-    var destinationLongitude by rememberSaveable { mutableStateOf("17.0312766") }
 
     AlertDialog(
         onDismissRequest = {
@@ -39,7 +37,7 @@ fun AddOrderDialog(setShowDialog: (Boolean) -> Unit, onConfirm: (String, String,
                 onClick = {
                     // Change the state to close the dialog
                     setShowDialog(false)
-                    onConfirm(orderName, destinationLatitude, destinationLongitude)
+                    onConfirm(orderName)
                 },
             ) {
                 Text(stringResource(id = R.string.add_order_dialog_confirm_button))
@@ -48,14 +46,6 @@ fun AddOrderDialog(setShowDialog: (Boolean) -> Unit, onConfirm: (String, String,
         text = {
             Column {
                 TextInput(orderName, R.string.add_order_dialog_order_name_hint) { orderName = it }
-                TextInput(
-                    destinationLatitude,
-                    R.string.add_order_dialog_order_latitude_hint
-                ) { destinationLatitude = it }
-                TextInput(
-                    destinationLongitude,
-                    R.string.add_order_dialog_order_longitude_hint
-                ) { destinationLongitude = it }
             }
         },
     )

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainScreen.kt
@@ -50,8 +50,8 @@ fun MainScreen(viewModel: MainViewModel) {
         modifier = Modifier.fillMaxSize(),
         content = {
             val state = viewModel.state.collectAsState()
-            MainScreenContent(state.value) { name, destinationLatitude, destinationLongitude ->
-                viewModel.addOrder(name, destinationLatitude, destinationLongitude)
+            MainScreenContent(state.value) { name ->
+                viewModel.addOrder(name)
             }
         },
     )
@@ -59,7 +59,7 @@ fun MainScreen(viewModel: MainViewModel) {
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun MainScreenContent(state: MainScreenState, onAddTrackable: (String, String, String) -> Unit) {
+fun MainScreenContent(state: MainScreenState, onAddTrackable: (String) -> Unit) {
     val (showDialog, setShowDialog) = remember { mutableStateOf(false) }
     LazyColumn {
         stickyHeader {
@@ -111,11 +111,11 @@ fun MainScreenContentPreview() {
             OrderViewItem(name = "Sushi", R.string.trackable_state_publishing, {}, {})
         )
     )
-    MainScreenContent(state) { _, _, _ -> }
+    MainScreenContent(state) { }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun AddOrderDialogPreview() {
-    AddOrderDialog({}) { _, _, _ -> }
+    AddOrderDialog({}) { }
 }

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainViewModel.kt
@@ -77,13 +77,9 @@ class MainViewModel(
         trackableStates.remove(trackableId)
     }
 
-    fun addOrder(orderName: String, destinationLatitude: String, destinationLongitude: String) =
+    fun addOrder(orderName: String) =
         launch {
-            orderManager.assignOrder(
-                orderName,
-                destinationLatitude.toDouble(),
-                destinationLongitude.toDouble()
-            )
+            orderManager.assignOrder(orderName)
         }
 
     fun onSettingsClicked() {

--- a/app/src/test/java/com/ably/tracking/demo/publisher/api/FakeDeliveryServiceDataSource.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/api/FakeDeliveryServiceDataSource.kt
@@ -19,11 +19,12 @@ class FakeDeliveryServiceDataSource : DeliveryServiceDataSource {
         return ablyToken
     }
 
-    override suspend fun deleteOrder(authBase64: String, orderId: Long) {
+    override suspend fun assignOrder(authBase64: String, orderId: Long): Destination {
         lastAuthorizationHeader = authBase64
+        return Destination(0.0, 0.0)
     }
 
-    override suspend fun assignOrder(authBase64: String, orderId: Long) {
+    override suspend fun deleteOrder(authBase64: String, orderId: Long) {
         lastAuthorizationHeader = authBase64
     }
 }

--- a/app/src/test/java/com/ably/tracking/demo/publisher/domain/FakeOrderInteractor.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/domain/FakeOrderInteractor.kt
@@ -13,11 +13,7 @@ class FakeOrderInteractor : OrderManager {
         // no-op
     }
 
-    override suspend fun assignOrder(
-        orderId: String,
-        destinationLatitude: Double,
-        destinationLongitude: Double
-    ) {
+    override suspend fun assignOrder(orderId: String) {
         orders.emit(orders.value.plus(Order(orderId, OrderState.Offline)))
     }
 

--- a/app/src/test/java/com/ably/tracking/demo/publisher/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/ui/main/MainViewModelTest.kt
@@ -12,10 +12,6 @@ import org.junit.Test
 
 @ExperimentalCoroutinesApi
 internal class MainViewModelTest : BaseViewModelTest() {
-
-    private val destinationLatitude = "51.1065859"
-    private val destinationLongitude = "17.0312766"
-
     private val navigator = FakeNavigator()
 
     private val orderInteractor = FakeOrderInteractor()
@@ -29,7 +25,7 @@ internal class MainViewModelTest : BaseViewModelTest() {
         viewModel.onLocationPermissionGranted()
 
         // when
-        viewModel.addOrder(orderName, destinationLatitude, destinationLongitude)
+        viewModel.addOrder(orderName)
 
         // then
         val order = viewModel.state.value.orders.firstOrNull { it.name == orderName }
@@ -43,7 +39,7 @@ internal class MainViewModelTest : BaseViewModelTest() {
             // given
             val orderName = "Sushi"
             viewModel.onLocationPermissionGranted()
-            viewModel.addOrder(orderName, destinationLatitude, destinationLongitude)
+            viewModel.addOrder(orderName)
 
             // when
             orderInteractor.updateOrderState(orderName, OrderState.Publishing)
@@ -59,7 +55,7 @@ internal class MainViewModelTest : BaseViewModelTest() {
             // given
             val orderName = "Pancake"
             viewModel.onLocationPermissionGranted()
-            viewModel.addOrder(orderName, destinationLatitude, destinationLongitude)
+            viewModel.addOrder(orderName)
 
             // when
             viewModel.state.value.orders.first().onTrackClicked()
@@ -74,7 +70,7 @@ internal class MainViewModelTest : BaseViewModelTest() {
             // given
             val orderName = "Pancake"
             viewModel.onLocationPermissionGranted()
-            viewModel.addOrder(orderName, destinationLatitude, destinationLongitude)
+            viewModel.addOrder(orderName)
 
             // when
             viewModel.state.value.orders.first().onRemoveClicked()


### PR DESCRIPTION
Removed unnecessary latitude and longitude inputs from assign order dialog, app will be using values returned from the backend instead