### PR TITLE
trackable references renamed to order

### DIFF
--- a/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainScreen.kt
@@ -129,7 +129,7 @@ fun OrderRow(order: OrderViewItem) {
 @Preview(showBackground = true)
 @Composable
 fun OrderRowPreview() {
-    val order = OrderViewItem(name = "Burger", R.string.trackable_state_online, {}, {})
+    val order = OrderViewItem(name = "Burger", R.string.order_state_online, {}, {})
     AATPublisherDemoTheme {
         OrderRow(order = order)
     }
@@ -140,9 +140,9 @@ fun OrderRowPreview() {
 fun MainScreenContentPreview() {
     val state = MainScreenState(
         listOf(
-            OrderViewItem(name = "Burger", R.string.trackable_state_online, {}, {}),
-            OrderViewItem(name = "Pizza", R.string.trackable_state_offline, {}, {}),
-            OrderViewItem(name = "Sushi", R.string.trackable_state_publishing, {}, {})
+            OrderViewItem(name = "Burger", R.string.order_state_online, {}, {}),
+            OrderViewItem(name = "Pizza", R.string.order_state_offline, {}, {}),
+            OrderViewItem(name = "Sushi", R.string.order_state_publishing, {}, {})
         )
     )
     AATPublisherDemoTheme {

--- a/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/ably/tracking/demo/publisher/ui/main/MainViewModel.kt
@@ -1,7 +1,6 @@
 package com.ably.tracking.demo.publisher.ui.main
 
 import androidx.annotation.StringRes
-import com.ably.tracking.TrackableState
 import com.ably.tracking.demo.publisher.R
 import com.ably.tracking.demo.publisher.common.BaseViewModel
 import com.ably.tracking.demo.publisher.domain.Order
@@ -10,8 +9,6 @@ import com.ably.tracking.demo.publisher.domain.OrderState
 import com.ably.tracking.demo.publisher.ui.navigation.Navigator
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -23,8 +20,6 @@ class MainViewModel(
     BaseViewModel(coroutineScope) {
 
     val state: MutableStateFlow<MainScreenState> = MutableStateFlow(MainScreenState())
-
-    private val trackableStates = mutableMapOf<String, StateFlow<TrackableState>>()
 
     init {
         launch {
@@ -58,23 +53,22 @@ class MainViewModel(
 
     @StringRes
     fun OrderState.toStringRes(): Int = when (this) {
-        OrderState.Online -> R.string.trackable_state_online
-        OrderState.Publishing -> R.string.trackable_state_publishing
-        OrderState.Failed -> R.string.trackable_state_failed
-        OrderState.Offline -> R.string.trackable_state_offline
+        OrderState.Online -> R.string.order_state_online
+        OrderState.Publishing -> R.string.order_state_publishing
+        OrderState.Failed -> R.string.order_state_failed
+        OrderState.Offline -> R.string.order_state_offline
     }
 
     fun onLocationPermissionGranted() = launch {
         orderManager.connect()
     }
 
-    private fun onTrackCLicked(trackableId: String) = launch {
-        orderManager.pickUpOrder(trackableId)
+    private fun onTrackCLicked(orderID: String) = launch {
+        orderManager.pickUpOrder(orderID)
     }
 
-    private fun onRemoveClicked(trackableId: String) = launch {
-        orderManager.removeOrder(trackableId)
-        trackableStates.remove(trackableId)
+    private fun onRemoveClicked(orderID: String) = launch {
+        orderManager.removeOrder(orderID)
     }
 
     fun addOrder(orderName: String) =

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,10 +18,10 @@
     <string name="location_permission_denied_dialog_title">Location permission required</string>
     <string name="location_permission_denied_dialog_message">This application requires location permission to work</string>
     <string name="ok">OK</string>
-    <string name="trackable_state_online">Online</string>
-    <string name="trackable_state_publishing">Publishing</string>
-    <string name="trackable_state_offline">Offline</string>
-    <string name="trackable_state_failed">Failed</string>
+    <string name="order_state_online">Online</string>
+    <string name="order_state_publishing">Publishing</string>
+    <string name="order_state_offline">Offline</string>
+    <string name="order_state_failed">Failed</string>
     <string name="settings_screen_title">Debug Settings</string>
     <string name="settings_screen_back_description">Back</string>
     <string name="settings_screen_close_session_button_text">Close session and save logs</string>

--- a/app/src/test/java/com/ably/tracking/demo/publisher/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/ably/tracking/demo/publisher/ui/main/MainViewModelTest.kt
@@ -30,7 +30,7 @@ internal class MainViewModelTest : BaseViewModelTest() {
         // then
         val order = viewModel.state.value.orders.firstOrNull { it.name == orderName }
         assertThat(order).isNotNull()
-        assertThat(order!!.state).isEqualTo(R.string.trackable_state_offline)
+        assertThat(order!!.state).isEqualTo(R.string.order_state_offline)
     }
 
     @Test
@@ -46,11 +46,11 @@ internal class MainViewModelTest : BaseViewModelTest() {
 
             // then
             val order = viewModel.state.value.orders.first { it.name == orderName }
-            assertThat(order.state).isEqualTo(R.string.trackable_state_publishing)
+            assertThat(order.state).isEqualTo(R.string.order_state_publishing)
         }
 
     @Test
-    fun `onTrack clicked selected trackable is tracked`() =
+    fun `onTrack clicked selected order is tracked`() =
         runTest {
             // given
             val orderName = "Pancake"
@@ -65,7 +65,7 @@ internal class MainViewModelTest : BaseViewModelTest() {
         }
 
     @Test
-    fun `on remove clicked selected trackable is removed`() =
+    fun `on remove clicked selected order is removed`() =
         runTest {
             // given
             val orderName = "Pancake"


### PR DESCRIPTION
This PR renames most usages of `trackable` to `order` both in the code and in the UI.

Completes #14 